### PR TITLE
Update blend-exchange domain

### DIFF
--- a/blendexchanger.user.js
+++ b/blendexchanger.user.js
@@ -24,7 +24,7 @@ function shortcutShouldFire(ev) {
 }
 
 // URL of blend-exchange embedded upload view
-const SiteURL = "https://blend-exchange.giantcowfilms.com"
+const SiteURL = "https://blend-exchange.com"
 const EmbedURL = SiteURL + "/embedUpload/?qurl=" + document.URL;
 
 //Quiet debugging prints


### PR DESCRIPTION
Blend-exchange has moved from blend-exchange.giantcowfilms.com to blend-exchange.com. This commit updates the user script to the new domain.